### PR TITLE
Symlink Ruby 1.8 to 2.0.0

### DIFF
--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -13,3 +13,10 @@ chmod 700 /Users/vagrant/.ssh
 curl -k 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' > /Users/vagrant/.ssh/authorized_keys
 chmod 600 /Users/vagrant/.ssh/authorized_keys
 chown -R vagrant /Users/vagrant/.ssh
+
+# If we're on 10.9 we need to symlink the site_suby folder so Puppet and Chef install to the right place.
+
+if [ "$OSX_VERS" -ge 9 ]; then
+    rm -rf /usr/lib/ruby/site_ruby/1.8
+    ln -s /usr/lib/ruby/site_ruby/2.0.0/ /usr/lib/ruby/site_ruby/1.8
+fi


### PR DESCRIPTION
The Puppet installer still installs to `/usr/lib/ruby/site_ruby/1.8`. This creates a symlink before Puppet is installed so Puppet provisioning will now work!
