### PR TITLE
Refresh network interfaces each boot

### DIFF
--- a/packer/template.json
+++ b/packer/template.json
@@ -45,7 +45,8 @@
         "../scripts/vmware.sh",
         "../scripts/xcode-cli-tools.sh",
         "../scripts/chef-omnibus.sh",
-        "../scripts/puppet.sh"
+        "../scripts/puppet.sh",
+        "../scripts/add-network-interface-detection.sh"
       ],
       "type": "shell"
     },

--- a/scripts/add-network-interface-detection.sh
+++ b/scripts/add-network-interface-detection.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This script adds a Mac OS Launch Daemon, which runs every time the
+# machine is booted. The daemon will re-detect the attached network
+# interfaces. If this is not done, network devices may not work.
+
+sudo cat <<EOF > /Library/LaunchDaemons/com.github.timsutton.osx-vm-templates.detectnewhardware.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.github.timsutton.osx-vm-templates.detectnewhardware</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/sbin/networksetup</string>
+        <string>-detectnewhardware</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+exit


### PR DESCRIPTION
This is necessary because Mavericks doesn't seem to automatically detect any changed network interfaces until the Network Preference pane is opened. By running "sudo networksetup -detectnewhardware" on each boot, the new network adapters are detected.

This change adds a Launch Daemon, which will run every time the machine is booted, that will refresh the network adapters configuration. This ensures that the machine will always have connectivity automatically immediately after boot.

Incorporates [feedback](https://github.com/99designs/osx-vm-templates/commit/07264f3ac23f25fcc593a31aa87588ad81bb84d8#commitcomment-4733440) on the initial implementation from @timsutton. Thanks!
