### PR TITLE
update vmware tools install script for packer 0.5

### DIFF
--- a/scripts/vmware.sh
+++ b/scripts/vmware.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # VMware Fusion specific items
-if [ -e .vmfusion_version ] || [ "$PACKER_BUILDER_TYPE" = "vmware" ]; then
+if [ -e .vmfusion_version ] || [[ "$PACKER_BUILDER_TYPE" == vmware* ]]; then
     TMPMOUNT=`/usr/bin/mktemp -d /tmp/vmware-tools.XXXX`
     hdiutil attach darwin.iso -mountpoint "$TMPMOUNT"
     installer -pkg "$TMPMOUNT/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg" -target /


### PR DESCRIPTION
Building on #3 

I noticed that vmware tools don't install with Packer 0.5. This manifests itself as HGFS kernel errors when doing a `vagrant up`.

This PR changes the vmware detection logic to match the start of the `PACKER_BUILDER_TYPE` string so it should be backwards compatible and work with both of the new provisioners.

https://github.com/mitchellh/packer/blob/master/CHANGELOG.md#050-12302013
