### PR TITLE
Update Vagrant key location + follow redirects

### DIFF
--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -10,6 +10,6 @@ scutil --set HostName ${COMPNAME}.vagrantup.com
 # Installing vagrant keys
 mkdir /Users/vagrant/.ssh
 chmod 700 /Users/vagrant/.ssh
-curl -k 'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub' > /Users/vagrant/.ssh/authorized_keys
+curl -k -L 'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub' > /Users/vagrant/.ssh/authorized_keys
 chmod 600 /Users/vagrant/.ssh/authorized_keys
 chown -R vagrant /Users/vagrant/.ssh


### PR DESCRIPTION
It seems that Github changed location of raw files (I assume it's now under CDN as the rest of the static content).
The `curl` doesn't follow the new location by default if it gets `3xx` response, so the key will be missing in the box.

I've updated the URL and added the [-L option](http://curl.haxx.se/docs/manpage.html#-L) which will prevent these issues in the future.
