### PR TITLE
`vagrant` user may need `vagrant` group

### DIFF
--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -13,3 +13,7 @@ chmod 700 /Users/vagrant/.ssh
 curl -L 'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub' > /Users/vagrant/.ssh/authorized_keys
 chmod 600 /Users/vagrant/.ssh/authorized_keys
 chown -R vagrant /Users/vagrant/.ssh
+
+# Create vagrant group and assign vagrant user to it
+dseditgroup -o create vagrant
+dseditgroup -o edit -a vagrant vagrant


### PR DESCRIPTION
Trying to use `rsync`-style shared folder support, I get this:

```
==> default: Rsyncing folder: /Users/matt/src/brewdo/ => /vagrant
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

find '/vagrant' '(' ! -user vagrant -or ! -group vagrant ')' -print0 | xargs -0 -r chown vagrant:vagrant

Stdout from the command:



Stderr from the command:

xargs: illegal option -- r
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]
find: -group: vagrant: no such group
```

The `-r` option for `xargs` requires some extra work on Vagrant's end, but I think the `vagrant` group is something that can be done in `prepare_iso` (Vagrant boxes for other OSes have this.)  Unfortunately, I'm not sure where to start looking for this.

Note: I am using the prerelease Packer with SATA ISO support for VirtualBox (https://github.com/mitchellh/packer/pull/1200) and the small work that I've done adding that support to the Packer template (https://github.com/zigg/osx-vm-templates/commit/e9dd4034ae8ac4a13aed8cb54267458b7fa23b3a) but I expect this behaves similarly under VMware.  The `Vagrantfile` required to trigger this looks like this:

```
# -*- mode: ruby -*-
# vi: set ft=ruby :

# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
VAGRANTFILE_API_VERSION = "2"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "osx109"
  config.vm.synced_folder ".", "/vagrant", type: "rsync"
end
```
