### PR TITLE
XCode CLI Tools script: Add support for OS X 10.10

### DIFF
--- a/scripts/xcode-cli-tools.sh
+++ b/scripts/xcode-cli-tools.sh
@@ -3,19 +3,20 @@
 # Get and install Xcode CLI tools
 OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
  
-# on 10.9, we can leverage SUS to get the latest CLI tools
+# on 10.9+, we can leverage SUS to get the latest CLI tools
 if [ "$OSX_VERS" -ge 9 ]; then
 
     # create the placeholder file that's checked by CLI updates' .dist code 
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 
-    # find the update with "Developer" in the name
-    PROD=$(softwareupdate -l | grep -B 1 "Developer" | head -n 1 | awk -F"*" '{print $2}')
+    # find the CLI Tools update
+    [ "$OSX_VERS" -ge 10 ] && PROD=$(softwareupdate -l | grep "Command Line" | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    [ "$OSX_VERS" -eq 9 ] && PROD=$(softwareupdate -l | grep -B 1 "Developer" | head -n 1 | awk -F"*" '{print $2}')
 
     # install it
     # amazingly, it won't find the update if we put the update ID in double-quotes
-    softwareupdate -i $PROD -v
+    softwareupdate -i "$PROD" -v
  
 # on 10.7/10.8, we instead download from public download URLs, which can be found in
 # the dvtdownloadableindex:


### PR DESCRIPTION
Surprisingly the "hack" works almost the same way except they've renamed the update in the last OS X.

Here's the full output from `softwareupdate -l`:

```
Software Update Tool
Copyright 2002-2012 Apple Inc.

Finding available software
Software Update found the following new or updated software:
   * Command Line Tools (OS X 10.10)-6.0
    Command Line Tools (OS X 10.10) (6.0), 108534K [recommended]
   * iTunesX-12.0
    iTunes (12.0), 160725K [recommended]
```

btw. In case you'd be curious, I actually had to install the Yosemite manually onto a fresh 10.9, because there are still some known issues with fresh 10.10 installations, so the whole setup has not been fully tested for `10.10` yet.
