### PR TITLE
Fix to keep only lines with *

### DIFF
--- a/scripts/xcode-cli-tools.sh
+++ b/scripts/xcode-cli-tools.sh
@@ -9,7 +9,7 @@ if [ "$OSX_VERS" -ge 9 ]; then
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     # find the CLI Tools update
-    PROD=$(softwareupdate -l | grep "Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
     # install it
     softwareupdate -i "$PROD" -v
  


### PR DESCRIPTION
Was broken with following  `softwareupdate -l` output:

Software Update Tool
Copyright 2002-2012 Apple Inc.

Finding available software
Software Update found the following new or updated software:
- 031-00536-5.1.0.0
      Command Line Developer Tools for OS X Mavericks (5.1.0.0), 121492K [recommended]
- Safari7.1Mavericks-7.1
      Safari (7.1), 59574K [recommended]
- Command Line Tools (OS X Mavericks)-6.0
      Command Line Tools (OS X 10.9) (6.0), 104398K [recommended]
- iBooksDelta-1.0.1
      iBooks Update (1.0.1), 14334K [recommended]
- iTunesXPatch-11.4
      iTunes (11.4), 94992K [recommended]
