### PR TITLE
Added Parallels support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer_cache
 *.box
 AutoPartition-*
 packer/output-*
+*.pvm

--- a/packer/template.json
+++ b/packer/template.json
@@ -1,6 +1,34 @@
 {
   "builders": [
     {
+      "boot_wait": "5s",
+      "disk_size": 40960,
+      "guest_os_type": "win-8",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "parallels_tools_flavor": "mac",
+      "type": "parallels-iso",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--memquota", "512:2048"],
+        ["set", "{{.Name}}", "--cpus", "2"],
+        ["set", "{{.Name}}", "--distribution", "macosx"],
+        ["set", "{{.Name}}", "--3d-accelerate", "highest"],
+        ["set", "{{.Name}}", "--high-resolution", "off"],
+        ["set", "{{.Name}}", "--auto-share-camera", "off"],
+        ["set", "{{.Name}}", "--auto-share-bluetooth", "off"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"],
+        ["set", "{{.Name}}", "--isolate-vm", "on"],
+        ["set", "{{.Name}}", "--shf-host", "off"]
+      ]
+    },
+    {
       "boot_wait": "2s",
       "disk_size": 20480,
       "guest_os_type": "darwin12-64",
@@ -74,6 +102,7 @@
       "scripts": [
         "../scripts/vagrant.sh",
         "../scripts/vmware.sh",
+        "../scripts/parallels.sh",
         "../scripts/xcode-cli-tools.sh",
         "../scripts/chef-omnibus.sh",
         "../scripts/puppet.sh",

--- a/scripts/parallels.sh
+++ b/scripts/parallels.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eo pipefail
+
+TOOLS_PATH="/Users/travis/prl-tools-mac.iso"
+# Parallels Tools specific items
+if [ -e .PACKER_BUILDER_TYPE ] || [[ "$PACKER_BUILDER_TYPE" == parallels* ]]; then
+    if [ ! -e "$TOOLS_PATH" ]; then
+        echo "Couldn't locate uploaded tools iso at $TOOLS_PATH!"
+        exit 1
+    fi
+
+    TMPMOUNT=`/usr/bin/mktemp -d /tmp/parallels-tools.XXXX`
+    hdiutil attach "$TOOLS_PATH" -mountpoint "$TMPMOUNT"
+
+    INSTALLER_PKG="$TMPMOUNT/Install.app/Contents/Resources/Install.mpkg"
+    if [ ! -e "$INSTALLER_PKG" ]; then
+        echo "Couldn't locate Parallels Tools installer pkg at $INSTALLER_PKG!"
+        exit 1
+    fi
+
+    echo "Installing Parallels Tools..."
+    installer -pkg "$INSTALLER_PKG" -target /
+
+    # This usually fails
+    hdiutil detach "$TMPMOUNT"
+    rm -rf "$TMPMOUNT"
+    rm -f "$TOOLS_PATH"
+fi


### PR DESCRIPTION
Parallels builder requires some hack: First we set guest_os_type to win-8 and later we change it to osx. It's due to some buggy handling of hard disk creation during machine provisioning. Everything else works as expected.
