### PR TITLE
use latest xcode-cli update

### DIFF
--- a/scripts/xcode-cli-tools.sh
+++ b/scripts/xcode-cli-tools.sh
@@ -9,7 +9,7 @@ if [ "$OSX_VERS" -ge 9 ]; then
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     # find the CLI Tools update
-    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
     # install it
     softwareupdate -i "$PROD" -v
  


### PR DESCRIPTION
Thanks for your effort to make Yosemite work!
I have seen that there are more than one update for the XCode Command Line tools. The script uses the old one. I have changed the script to pick the latest update.

A sample output in my Yosemite box looks like this:

```
vagrant-osx-10-10:~ vagrant$ touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
vagrant-osx-10-10:~ vagrant$ softwareupdate -l
Software Update Tool
Copyright 2002-2012 Apple Inc.

Finding available software
Software Update found the following new or updated software:
   * Command Line Tools (OS X 10.10)-6.0
	Command Line Tools (OS X 10.10) (6.0), 108642K [recommended]
   * Command Line Tools (OS X 10.10)-6.0
	Command Line Tools (OS X 10.10) (6.0), 109114K [recommended]
   * Command Line Tools (OS X 10.10)-6.0
	Command Line Tools (OS X 10.10) (6.0), 109150K [recommended]
   * Command Line Tools (OS X 10.10)-6.1
	Command Line Tools (OS X 10.10) (6.1), 173638K [recommended]
```

So I used a `tail -n 1` instead of the `head -n 1` to pick the right one. 
