### PR TITLE
Fix vagrant.sh hanging when executing dseditgroup.

### DIFF
--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -19,5 +19,7 @@ if [ "$INSTALL_VAGRANT_KEYS" = "true" ] || [ "$INSTALL_VAGRANT_KEYS" = "1" ]; th
 fi
 
 # Create a group and assign the user to it
-dseditgroup -o create "$USERNAME"
-dseditgroup -o edit -a "$USERNAME" "$USERNAME"
+dseditgroup -q -o create "$USERNAME"
+dseditgroup -q -o edit -a "$USERNAME" "$USERNAME"
+
+exit

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -21,5 +21,3 @@ fi
 # Create a group and assign the user to it
 dseditgroup -q -o create "$USERNAME"
 dseditgroup -q -o edit -a "$USERNAME" "$USERNAME"
-
-exit


### PR DESCRIPTION
Related to [issue #31](https://github.com/timsutton/osx-vm-templates/issues/31) 

So, VPN issues are present but not the cause of this. The root cause has to do with the dseditgroup command when called on some environments. Passing in the `-q` flag disables interactive verification, thus preventing the script from hanging. 
