### PR TITLE
Script to help reduce generated box size

### DIFF
--- a/packer/template.json
+++ b/packer/template.json
@@ -108,7 +108,8 @@
         "../scripts/puppet.sh",
         "../scripts/add-network-interface-detection.sh",
         "../scripts/autologin.sh",
-        "../scripts/system-update.sh"
+        "../scripts/system-update.sh",
+        "../scripts/shrink.sh"
       ],
       "environment_vars": [
         "AUTOLOGIN={{user `autologin`}}",

--- a/scripts/shrink.sh
+++ b/scripts/shrink.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Turn off hibernation and get rid of the sleepimage
+pmset hibernatemode 0
+rm -f /var/vm/sleepimage
+
+# Stop the pager process and drop swap files. These will be re-created on boot
+launchctl unload /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist
+sleep 5
+rm -rf /private/var/vm/swap*
+
+# VMware Fusion specific items
+if [ -e .vmfusion_version ] || [[ "$PACKER_BUILDER_TYPE" == vmware* ]]; then
+    # Shrink the disk
+    sudo /Library/Application\ Support/VMware\ Tools/vmware-tools-cli disk shrink /
+fi


### PR DESCRIPTION
This script disables hibernation, removes the sleepimage and deletes
any swapfiles. This reduces uneeded space on disk. Swapfiles will be
re-genereated as needed. If the box is for VMware, it will also make
VMware shrink the disk image via VMware tools. On a Yosemite box
made today this resulted in a reduction from ~14G to ~7G