### PR TITLE
update VirtualBox settings to match current built-in OS X template

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,6 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-#### Additional VM configuration for Packer
-
-So far we've seen that the `--cpuidset` option needs to be passed to `modifyvm` as a line in the packer template if a Haswell Intel Mac is used to build the VM, at least as of VirtualBox 4.3.12. It seems to cause a VM crash on at least one older Mac, a Core 2 Duo-based 2010 Mac Mini, though did not cause issues on an Ivy Bridge 2013 iMac I tested. If it's missing on a Haswell Mac, however, the VM hangs indefinitely. This behaviour is likely to change over time as Oracle keeps up with support for OS X guests.
-
-```json
-      "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"],
-      ]
-```
-
 
 ## Box sizes
 

--- a/packer/template.json
+++ b/packer/template.json
@@ -60,7 +60,7 @@
       "boot_wait": "2s",
       "disk_size": 40960,
       "guest_additions_mode": "disable",
-      "guest_os_type": "MacOS109_64",
+      "guest_os_type": "MacOS1011_64",
       "hard_drive_interface": "sata",
       "iso_checksum_type": "md5",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -77,13 +77,14 @@
         ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
         ["modifyvm", "{{.Name}}", "--boot2", "disk"],
         ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-        ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"],
         ["modifyvm", "{{.Name}}", "--firmware", "efi"],
         ["modifyvm", "{{.Name}}", "--hpet", "on"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
         ["modifyvm", "{{.Name}}", "--memory", "2048"],
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
-        ["modifyvm", "{{.Name}}", "--vram", "9"]
+        ["modifyvm", "{{.Name}}", "--usbehci", "on"],
+        ["modifyvm", "{{.Name}}", "--vram", "16"],
+        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"]
       ]
     }
   ],
@@ -131,8 +132,8 @@
     "facter_version": "latest",
     "hiera_version": "latest",
     "install_vagrant_keys": "true",
-    "iso_checksum": "aff67f81dfbad7afda56c423473d61a6",
-    "iso_url": "OSX_InstallESD_10.9.3_13D65.dmg",
+    "iso_checksum": "b78fef812ca50da24381e45e56fb9285",
+    "iso_url": "OSX_InstallESD_10.11.1_15B42.dmg",
     "password": "vagrant",
     "puppet_version": "latest",
     "update_system": "true",


### PR DESCRIPTION
Did this on the way to fixing #43. It didn't fix the issue, but I think it's worth tracking VirtualBox's default OS X template closely.

Of note, I removed the `cpuidset` that we used to need for Haswell support (cf. https://github.com/timsutton/osx-vm-templates/pull/13#issuecomment-44215234) We clearly don't need it anymore. 👍🏻 