### PR TITLE
prepare_iso disable flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This project currently only supplies a single Packer template (`template.json`),
 
 OS X's installer cannot be bootstrapped as easily as can Linux or Windows, and so exists the [prepare_iso.sh](https://github.com/timsutton/osx-vm-templates/blob/master/prepare_iso/prepare_iso.sh) script to perform modifications to it that will allow for an automated install and ultimately allow Packer and later, Vagrant, to have SSH access.
 
+**Note:** VirtualBox users currently have to disable Remote Management to avoid [periodic freezing](https://github.com/timsutton/osx-vm-templates/issues/43) of the VM by adding `-D DISABLE_REMOTE_MANAGEMENT` to the `prepare_iso.sh` options. See [Remote Management freezing issue](#remote-management-freezing-issue) for more information.
+
 Run the `prepare_iso.sh` script with two arguments: the path to an `Install OS X.app` or the `InstallESD.dmg` contained within, and an output directory. Root privileges are required in order to write a new DMG with the correct file ownerships. For example, with a 10.8.4 Mountain Lion installer:
 
 `sudo prepare_iso/prepare_iso.sh "/Applications/Install OS X Mountain Lion.app" out`
@@ -40,7 +42,7 @@ Run the `prepare_iso.sh` script with two arguments: the path to an `Install OS X
 -- Done. Built image is located at out/OSX_InstallESD_10.8.4_12E55.dmg. Add this iso and its checksum to your template.
 ```
 
-`prepare_iso.sh` also accepts three command line switches to modify the details of the admin user installed by the script.
+`prepare_iso.sh` accepts command line switches to modify the details of the admin user installed by the script.
 
 * `-u` modifies the name of the admin account, defaulting to `vagrant`
 * `-p` modifies the password of the same account, defaulting to `vagrant`
@@ -49,6 +51,11 @@ Run the `prepare_iso.sh` script with two arguments: the path to an `Install OS X
 For example:
 
 `sudo prepare_iso/prepare_iso.sh -u admin -p password -i /path/to/image.jpg "/Applications/Install OS X Mountain Lion.app" out`
+
+Additionally, flags can be set to disable certain default configuration options.
+
+* `-D DISABLE_REMOTE_MANAGEMENT` disables the Remote Management service.
+* `-D DISABLE_SCREEN_SHARING` disables the Screen Sharing service.
 
 #### Clone this repository
 
@@ -117,6 +124,14 @@ packer build -var update_system=0 template.json
 VirtualBox support is thanks entirely to contributions by [Matt Behrens (@zigg)](https://github.com/zigg) to this repo, Vagrant and Packer.
 
 ### Caveats
+
+#### Remote Management freezing issue
+
+The default `prepare_iso.sh` configuration enables Remote Management during installation, which causes the resulting virtual machine to [periodically freeze](https://github.com/timsutton/osx-vm-templates/issues/43). You can avoid enabling Remote Management when using `prepare_iso.sh` by passing `-D DISABLE_REMOTE_MANAGEMENT` this:
+
+```
+sudo prepare_iso -D DISABLE_REMOTE_MANAGEMENT "/Applications/Install OS X El Capitan.app" out
+```
 
 #### Shared folders
 

--- a/prepare_iso/support/pkg-postinstall
+++ b/prepare_iso/support/pkg-postinstall
@@ -9,17 +9,23 @@ if [ "$OSX_VERS" -ge 10 ]; then
     OVERRIDES_PLIST="$3/private/var/db/com.apple.xpc.launchd/disabled.plist"
     $PlistBuddy -c 'Delete :com.openssh.sshd' "$OVERRIDES_PLIST"
     $PlistBuddy -c 'Add :com.openssh.sshd bool False' "$OVERRIDES_PLIST"
-    $PlistBuddy -c 'Delete :com.apple.screensharing' "$OVERRIDES_PLIST"
-    $PlistBuddy -c 'Add :com.apple.screensharing bool False' "$OVERRIDES_PLIST"
+    if [ __DISABLE_SCREEN_SHARING__ = 0 ]; then
+        $PlistBuddy -c 'Delete :com.apple.screensharing' "$OVERRIDES_PLIST"
+        $PlistBuddy -c 'Add :com.apple.screensharing bool False' "$OVERRIDES_PLIST"
+    fi
 else
     OVERRIDES_PLIST="$3/private/var/db/launchd.db/com.apple.launchd/overrides.plist"
     $PlistBuddy -c 'Delete :com.openssh.sshd' "$OVERRIDES_PLIST"
     $PlistBuddy -c 'Add :com.openssh.sshd:Disabled bool False' "$OVERRIDES_PLIST"
-    $PlistBuddy -c 'Delete :com.apple.screensharing' "$OVERRIDES_PLIST"
-    $PlistBuddy -c 'Add :com.apple.screensharing:Disabled bool False' "$OVERRIDES_PLIST"
+    if [ __DISABLE_SCREEN_SHARING__ = 0 ]; then
+        $PlistBuddy -c 'Delete :com.apple.screensharing' "$OVERRIDES_PLIST"
+        $PlistBuddy -c 'Add :com.apple.screensharing:Disabled bool False' "$OVERRIDES_PLIST"
+    fi
 fi
 # Placeholder for Remote Management
-echo "enabled" > "$3/private/etc/RemoteManagement.launchd"
+if [ __DISABLE_REMOTE_MANAGEMENT__ = 0 ]; then
+    echo "enabled" > "$3/private/etc/RemoteManagement.launchd"
+fi
 
 # Add user to sudoers
 cp "$3/etc/sudoers" "$3/etc/sudoers.orig"

--- a/prepare_iso/support/pkg-postinstall
+++ b/prepare_iso/support/pkg-postinstall
@@ -22,10 +22,6 @@ else
         $PlistBuddy -c 'Add :com.apple.screensharing:Disabled bool False' "$OVERRIDES_PLIST"
     fi
 fi
-# Placeholder for Remote Management
-if [ __DISABLE_REMOTE_MANAGEMENT__ = 0 ]; then
-    echo "enabled" > "$3/private/etc/RemoteManagement.launchd"
-fi
 
 # Add user to sudoers
 cp "$3/etc/sudoers" "$3/etc/sudoers.orig"
@@ -35,6 +31,7 @@ echo "$USER ALL=(ALL) NOPASSWD: ALL" >> "$3/etc/sudoers"
 USER_GUID=$($PlistBuddy -c 'Print :generateduid:0' "$target_ds_node/users/$USER.plist")
 USER_UID=$($PlistBuddy -c 'Print :uid:0' "$target_ds_node/users/$USER.plist")
 $PlistBuddy -c 'Add :groupmembers: string '"$USER_GUID" "$target_ds_node/groups/admin.plist"
+
 # Add user to SSH SACL group membership
 ssh_group="${target_ds_node}/groups/com.apple.access_ssh.plist"
 $PlistBuddy -c 'Add :groupmembers array' "${ssh_group}"
@@ -42,10 +39,12 @@ $PlistBuddy -c 'Add :groupmembers:0 string '"$USER_GUID"'' "${ssh_group}"
 $PlistBuddy -c 'Add :users array' "${ssh_group}"
 $PlistBuddy -c 'Add :users:0 string '$USER'' "${ssh_group}"
 
-# Configure user with full Remote Desktop privileges
-$PlistBuddy -c 'Add :naprivs array' "$target_ds_node/users/$USER.plist"
-$PlistBuddy -c 'Add :naprivs:0 string -1073741569' "$target_ds_node/users/$USER.plist"
-
+# Enable Remote Desktop and configure user with full privileges
+if [ __DISABLE_REMOTE_MANAGEMENT__ = 0 ]; then
+    echo "enabled" > "$3/private/etc/RemoteManagement.launchd"
+    $PlistBuddy -c 'Add :naprivs array' "$target_ds_node/users/$USER.plist"
+    $PlistBuddy -c 'Add :naprivs:0 string -1073741569' "$target_ds_node/users/$USER.plist"
+fi
 
 # Pre-create user folder so veewee will have somewhere to scp configinfo to
 mkdir -p "$3/Users/$USER/Library/Preferences"


### PR DESCRIPTION
This PR adds disable flags for Screen Sharing and Remote Management, the latter of which is currently required by #43 for VirtualBox to operate successfully.

The flag mechanism should be generally useful to selectively disable or enable additional features in the built DMG.