### PR TITLE
Fix vram size for hang starting virtualbox

### DIFF
--- a/packer/template.json
+++ b/packer/template.json
@@ -83,7 +83,7 @@
         ["modifyvm", "{{.Name}}", "--memory", "2048"],
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
         ["modifyvm", "{{.Name}}", "--usbehci", "on"],
-        ["modifyvm", "{{.Name}}", "--vram", "16"],
+        ["modifyvm", "{{.Name}}", "--vram", "33"],
         ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"]
       ]
     }


### PR DESCRIPTION
When OS X guest, Recommended vram size of Virtualbox is at 33MB or more.
In the case of 16MB, then hang immediately after starting Virtualbox.

```bash
> sw_vers
ProductName:    Mac OS X
ProductVersion: 10.11.1
BuildVersion:   15B42

> VBoxManage --version
5.0.10r104061
```

