### PR TITLE
Fix stat file path to absolute file path

### DIFF
--- a/prepare_iso/prepare_iso.sh
+++ b/prepare_iso/prepare_iso.sh
@@ -147,8 +147,8 @@ if [ -d "$ESD" ]; then
 fi
 
 VEEWEE_DIR="$(cd "$SCRIPT_DIR/../../../"; pwd)"
-VEEWEE_UID=$(stat -f %u "$VEEWEE_DIR")
-VEEWEE_GID=$(stat -f %g "$VEEWEE_DIR")
+VEEWEE_UID=$(/usr/bin/stat -f %u "$VEEWEE_DIR")
+VEEWEE_GID=$(/usr/bin/stat -f %g "$VEEWEE_DIR")
 DEFINITION_DIR="$(cd "$SCRIPT_DIR/.."; pwd)"
 
 if [ "$2" = "" ]; then


### PR DESCRIPTION
I as much as possible to follow to Linux (also GNU), I have installed `coreutils` with `--with-default-names` in Homebrew.
Also, `stat` is shell built-in command of `zsh`.

If using the stat of coreutils or zsh, 
```bash
# in zsh built-in stat,
stat: bad file descriptor
```

```bash
# in coreutils stat,
stat: cannot read file system information for ‘%u’: No such file or directory
```
that error will occur.

So, it was changed `stat` command path to an absolute path.

What do you think?