### PR TITLE
add provisioning_delay variable and provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Packer will instruct the system to download and install all available OS X updat
 packer build -var update_system=0 template.json
 ```
 
+## Provisioning delay
+
+In some cases, it may be helpful to insert a delay into the beginning of the provisioning process. Adding a delay of about 30 seconds may help subsequent provisioning steps that install software from the internet complete successfully. By default, the delay is set to `0`, but you can change the delay by setting the `provisioning_delay` variable:
+
+```
+packer build -var provisioning_delay=30 template.json`
+```
+
 ## VirtualBox support
 
 VirtualBox support is thanks entirely to contributions by [Matt Behrens (@zigg)](https://github.com/zigg) to this repo, Vagrant and Packer.

--- a/packer/template.json
+++ b/packer/template.json
@@ -94,6 +94,10 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "command": "sleep {{user `provisioning_delay`}}"
+    },
+    {
       "destination": "/private/tmp/set_kcpassword.py",
       "source": "../scripts/support/set_kcpassword.py",
       "type": "file"
@@ -135,6 +139,7 @@
     "iso_checksum": "b78fef812ca50da24381e45e56fb9285",
     "iso_url": "OSX_InstallESD_10.11.1_15B42.dmg",
     "password": "vagrant",
+    "provisioning_delay": "0",
     "puppet_version": "latest",
     "update_system": "true",
     "username": "vagrant"


### PR DESCRIPTION
This pull request provides a way for users to work around issue #59, "Sometimes xcode-cli-tools.sh hangs running softwareupdate", by adding a configurable delay to the start of the provisioning stage. The delay defaults to 0.