### PR TITLE
Don't install configuration management by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,18 @@ This was easily made possible thanks to Per Olofsson's [CreateUserPkg](http://ma
 
 ## Configuration management
 
-By default, the packer template installs the Chef and Puppet configuration management tools. You can disable the installation of configuration management entirely by setting the `nocm` variable to `true`:
+By default, the packer template does not install the Chef or Puppet configuration management tools. You can enable the installation of configuration management by setting the `chef_version`, `puppet_version`, `facter_version`, and `hiera_version` variables to `latest`, or to a specific version.
+
+To install the latest version of Chef:
 
 ```
-packer build -var nocm=true template.json
+packer build -var chef_version=latest template.json
+```
+
+To install the latest versions of Puppet, Facter and Hiera:
+
+```
+packer build -var puppet_version=latest facter_version=latest hiera_version=latest template.json
 ```
 
 ## Xcode Command Line Tools

--- a/packer/template.json
+++ b/packer/template.json
@@ -131,16 +131,15 @@
   ],
   "variables": {
     "autologin": "false",
-    "chef_version": "latest",
-    "facter_version": "latest",
-    "hiera_version": "latest",
+    "chef_version": "none",
+    "facter_version": "none",
+    "hiera_version": "none",
     "install_vagrant_keys": "true",
     "install_xcode_cli_tools": "true",
     "iso_url": "OSX_InstallESD_10.11.1_15B42.dmg",
-    "nocm": "false",
     "password": "vagrant",
     "provisioning_delay": "0",
-    "puppet_version": "latest",
+    "puppet_version": "none",
     "update_system": "true",
     "username": "vagrant"
   }

--- a/scripts/chef-omnibus.sh
+++ b/scripts/chef-omnibus.sh
@@ -5,6 +5,10 @@ if [[ "$NOCM" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
     exit
 fi
 
+if [ "${CHEF_VERSION}" == "none" ]; then
+    exit
+fi
+
 INSTALL_ARGS=""
 
 if [ "${CHEF_VERSION}" != "latest" ]; then

--- a/scripts/chef-omnibus.sh
+++ b/scripts/chef-omnibus.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # http://www.opscode.com/chef/install
 
-if [[ "$NOCM" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
-    exit
-fi
-
 if [ "${CHEF_VERSION}" == "none" ]; then
     exit
 fi

--- a/scripts/puppet.sh
+++ b/scripts/puppet.sh
@@ -59,15 +59,21 @@ AUTOPKG="$AUTOPKG_DIR/Code/autopkg"
 
 # Redirect AutoPkg cache to a temp location
 defaults write com.github.autopkg CACHE_DIR -string "$(mktemp -d /tmp/autopkg-cache-XXX)"
-# Retrieve the installer DMGs
-PUPPET_DMG=$(get_dmg Puppet.download "${PUPPET_VERSION}")
-FACTER_DMG=$(get_dmg Facter.download "${FACTER_VERSION}")
-HIERA_DMG=$(get_dmg Hiera.download "${HIERA_VERSION}")
 
-# Install them
-install_dmg "Puppet" "${PUPPET_DMG}"
-install_dmg "Facter" "${FACTER_DMG}"
-install_dmg "Hiera" "${HIERA_DMG}"
+if [ "${PUPPET_VERSION}" != "none" ]; then
+  PUPPET_DMG=$(get_dmg Puppet.download "${PUPPET_VERSION}")
+  install_dmg "Puppet" "${PUPPET_DMG}"
+fi
+
+if [ "${FACTER_VERSION}" != "none" ]; then
+  FACTER_DMG=$(get_dmg Facter.download "${FACTER_VERSION}")
+  install_dmg "Facter" "${FACTER_DMG}"
+fi
+
+if [ "${HIERA_VERSION}" != "none" ]; then
+  HIERA_DMG=$(get_dmg Hiera.download "${HIERA_VERSION}")
+  install_dmg "Hiera" "${HIERA_DMG}"
+fi
 
 # Hide all users from the loginwindow with uid below 500, which will include the puppet user
 defaults write /Library/Preferences/com.apple.loginwindow Hide500Users -bool YES

--- a/scripts/puppet.sh
+++ b/scripts/puppet.sh
@@ -8,7 +8,7 @@
 # install function mostly borrowed dmg function from hashicorp/puppet-bootstrap,
 # except we just take an already-downloaded dmg
 
-if [[ "$NOCM" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
+if [[ "${PUPPET_VERSION}" == "none" && "${FACTER_VERSION}" == "none" && "${HIERA_VERSION}" == "none" ]]; then
     exit
 fi
 


### PR DESCRIPTION
This builds on the changes in #62, which allows chef/puppet installation to be disabled by using version `none`. This change backs out the nocm variable support, which is now redundant, and disables installation of the tools by default, and updates the README to describe the new defaults and usage of the variables.