### PR TITLE
Support for installing macOS like AutoDMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Currently this prepare script and template supports all versions of OS X that ar
 
 This project currently only supplies a single Packer template (`template.json`), so the hypervisor's configured guest OS version (i.e. `darwin12-64`) does not accurately reflect the actual installed OS. I haven't found there to be any functional differences depending on these configured guest versions.
 
+To build a VMware box of an OS version less than El Capitan (10.11), note that as of VMare Fusion 8.5.4, you will need to change the `tools_upload_flavor` from `darwin` to `darwinPre15`.
+
 ## Preparing the ISO
 
 OS X's installer cannot be bootstrapped as easily as can Linux or Windows, and so exists the [prepare_iso.sh](https://github.com/timsutton/osx-vm-templates/blob/master/prepare_iso/prepare_iso.sh) script to perform modifications to it that will allow for an automated install and ultimately allow Packer and later, Vagrant, to have SSH access.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ This project currently only supplies a single Packer template (`template.json`),
 
 To build a VMware box of an OS version less than El Capitan (10.11), note that as of VMare Fusion 8.5.4, you will need to change the `tools_upload_flavor` from `darwin` to `darwinPre15`.
 
+## Issue with 10.12.4
+
+**Important note:** The Sierra 10.12.4 installer seems to no longer support including custom packages as part of the installer, unless they are signed by Apple. This produces an error with the text, "macOS could not be installed on your computer.. The package veewee-config.pkg is not signed."
+
+The `prepare_iso.sh` script in this repo makes use of functionality Apple supports as part of a [NetInstall workflow](https://help.apple.com/systemimageutility/mac/10.12/#/sysmb1457f0b), but because of this (undocumented) additional requirement of additional packages needing to be signed by Apple as of 10.12.4, these tools can't currently install the necessary configuration for Packer to log in to perform additional configuration, installing guest tools, etc. The rest of the OS install still completes successfully.
+
+It may be possible to work around this by modifying the rc script directly with the contents of our postinstall script.
+
 ## Preparing the ISO
 
 OS X's installer cannot be bootstrapped as easily as can Linux or Windows, and so exists the [prepare_iso.sh](https://github.com/timsutton/osx-vm-templates/blob/master/prepare_iso/prepare_iso.sh) script to perform modifications to it that will allow for an automated install and ultimately allow Packer and later, Vagrant, to have SSH access.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ The machine built by this Packer template defaults to being configured for use w
 - Vagrant's included [VirtualBox provider](http://docs.vagrantup.com/v2/virtualbox/index.html)
 - [Parallels](https://github.com/Parallels/vagrant-parallels)
 
-*Note*: People have [reported issues](https://github.com/timsutton/osx-vm-templates/issues/72) using VirtualBox as of version 5.1.x. The 5.0.x releases seem to still work.
-
 It's possible to build a machine with different admin account settings, and without the vagrant ssh keys, for use with other systems, e.g. continuous integration.
 
 Use with the Fusion provider requires Vagrant 1.3.0, and use with the VirtualBox provider Vagrant 1.6.3 if using the Rsync file sync mechanism. Note that the VeeWee template also does not have any VirtualBox or Parallels support.
@@ -172,15 +170,6 @@ The default `prepare_iso.sh` configuration enables Remote Management during inst
 sudo ./prepare_iso/prepare_iso.sh -D DISABLE_REMOTE_MANAGEMENT "/Applications/Install OS X El Capitan.app" out
 ```
 
-#### Extension Pack
-
-The VirtualBox Extension Pack, available from the [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads) page or as the [Homebrew cask](http://caskroom.io/) [virtualbox-extension-pack](https://github.com/caskroom/homebrew-cask/blob/master/Casks/virtualbox-extension-pack.rb), is now required by default because we enable EHCI (USB 2.0) support like the default VirtualBox OS X template does.
-
-If you cannot use the Extension Pack, you can remove the line that enables EHCI support from [`packer/template.json`](https://github.com/timsutton/osx-vm-templates/blob/master/packer/template.json):
-
-```
-        ["modifyvm", "{{.Name}}", "--usbehci", "on"],
-```
 
 #### Shared folders
 

--- a/packer/template.json
+++ b/packer/template.json
@@ -78,7 +78,6 @@
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
         ["modifyvm", "{{.Name}}", "--memory", "2048"],
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
-        ["modifyvm", "{{.Name}}", "--usbehci", "on"],
         ["modifyvm", "{{.Name}}", "--vram", "128"],
         ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"]
       ]

--- a/prepare_iso/create_firstboot_pkg.sh
+++ b/prepare_iso/create_firstboot_pkg.sh
@@ -13,11 +13,16 @@ DISABLE_REMOTE_MANAGEMENT=0
 DISABLE_SCREEN_SHARING=0
 DISABLE_SIP=0
 
+render_template() {
+  eval "echo \"$(cat "$1")\""
+}
+
 create_firstboot_pkg() {
   # payload items
   mkdir -p "$SUPPORT_DIR/pkgroot/private/var/db/dslocal/nodes/Default/users"
   mkdir -p "$SUPPORT_DIR/pkgroot/private/var/db/shadow/hash"
   BASE64_IMAGE=$(openssl base64 -in "$IMAGE_PATH")
+  ShadowHashData=$($SCRIPT_DIR/../scripts/support/generatehash.py "$PASSWORD")
   # Replace USER and BASE64_IMAGE in the user.plist file with the actual user and image
   render_template "$SUPPORT_DIR/user.plist" > "$SUPPORT_DIR/pkgroot/private/var/db/dslocal/nodes/Default/users/$USER.plist"
   USER_GUID=$(/usr/libexec/PlistBuddy -c 'Print :generateduid:0' "$SUPPORT_DIR/user.plist")

--- a/prepare_iso/prepare_vdi.sh
+++ b/prepare_iso/prepare_vdi.sh
@@ -23,12 +23,9 @@
 #
 #
 
-. $(dirname "$0")/create_firstboot_pkg.sh
-
 usage() {
 	cat <<EOF
 Usage:
-$(basename "$0") [-upiD] "/path/to/InstallESD.dmg" /path/to/output/directory
 $(basename "$0") [-upiD] "/path/to/Install OS X [Name].app" /path/to/output/directory
 
 Description:
@@ -58,17 +55,20 @@ EOF
 }
 
 cleanup() {
-	hdiutil detach -quiet -force "$MNT_ESD" || echo > /dev/null
-	hdiutil detach -quiet -force "$MNT_BASE_SYSTEM" || echo > /dev/null
-
-	if [ ! -z "$TEST" ]; then
-		cp "$BASE_SYSTEM_DMG_RW_SPARSE" "$BASE_SYSTEM_DMG_RW_SPARSE.back"
+	if [ ! -z "$MNT_ESD" ]; then
+		hdiutil detach -quiet -force "$MNT_ESD" || rm -rf "$MNT_ESD" || echo > /dev/null
 	fi
-	rm -rf "$MNT_ESD" "$MNT_BASE_SYSTEM" "$BASE_SYSTEM_DMG_RW" "${BASE_SYSTEM_DMG_RW%%.dmg}" "$BASE_SYSTEM_DMG_RW_SPARSE"
+
+	if [ ! -z "$MNT_SPARSEIMAGE" ]; then
+		hdiutil detach -quiet -force "$MNT_SPARSEIMAGE" || rm -rf "$MNT_SPARSEIMAGE" || echo > /dev/null
+	fi
+  
+	if [[ ! -z "$TEST" && -e "$SPARSEIMAGE" ]]; then
+		rm -rf "$SPARSEIMAGE"
+	fi
 }
 
 trap cleanup EXIT INT TERM
-
 
 msg_status() {
 	echo "\033[0;32m-- $1\033[0m"
@@ -76,28 +76,34 @@ msg_status() {
 msg_error() {
 	echo "\033[0;31m-- $1\033[0m"
 }
-
-render_template() {
-	eval "echo \"$(cat "$1")\""
-}
-
-if [ $# -eq 0 ]; then
-	usage
+exit_with_error() {
+	msg_error "$1"
 	exit 1
-fi
+}
 
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
 SUPPORT_DIR="$SCRIPT_DIR/support"
+
+# Import shared code to generate first boot pkgs
+FIRST_BOOT_PKG_SCRIPT="$SCRIPT_DIR/create_firstboot_pkg.sh"
+[ -f "$FIRST_BOOT_PKG_SCRIPT" ] && . "$FIRST_BOOT_PKG_SCRIPT"
 
 # Parse the optional command line switches
 USER="vagrant"
 PASSWORD="vagrant"
 IMAGE_PATH="$SUPPORT_DIR/vagrant.jpg"
+DISK_SIZE_GB=32
 
 # Flags
 DISABLE_REMOTE_MANAGEMENT=0
 DISABLE_SCREEN_SHARING=0
 DISABLE_SIP=0
+DISABLE_APFS=1
+
+if [ $# -eq 0 ]; then
+	usage
+	exit 1
+fi
 
 while getopts u:p:i:o:D: OPT; do
   case "$OPT" in
@@ -133,132 +139,126 @@ done
 shift $(expr $OPTIND - 1)
 
 if [ $(id -u) -ne 0 ]; then
-	msg_error "This script must be run as root, as it saves a disk image with ownerships enabled."
-	exit 1
+	exit_with_error "This script must be run as root, as it saves a disk image with ownerships enabled."
 fi
 
-ESD="$1"
-if [ ! -e "$ESD" ]; then
-	msg_error "Input installer image $ESD could not be found! Exiting.."
-	exit 1
+if [ -z "$(which VBoxManage)" ]; then
+	exit_with_error "VBoxManage, the command-line interface to VirtualBox, not found"
 fi
 
-if [ -d "$ESD" ]; then
-	# we might be an install .app
-	if [ -e "$ESD/Contents/SharedSupport/InstallESD.dmg" ]; then
-		ESD="$ESD/Contents/SharedSupport/InstallESD.dmg"
-	else
-		msg_error "Can't locate an InstallESD.dmg in this source location $ESD!"
-	fi
+INSTALLER_PATH="$1"
+if [ ! -e "$INSTALLER_PATH" ]; then
+	exit_with_error "Input installer image $INSTALLER_PATH could not be found! Exiting.."
 fi
 
-VEEWEE_DIR="$(cd "$SCRIPT_DIR/../../../"; pwd)"
-VEEWEE_UID=$(/usr/bin/stat -f %u "$VEEWEE_DIR")
-VEEWEE_GID=$(/usr/bin/stat -f %g "$VEEWEE_DIR")
-DEFINITION_DIR="$(cd "$SCRIPT_DIR/.."; pwd)"
-
-if [ "$2" = "" ]; then
-    msg_error "Currently an explicit output directory is required as the second argument."
-	exit 1
-	# The rest is left over from the old prepare_veewee_iso.sh script. Not sure if we
-    # should leave in this functionality to automatically locate the veewee directory.
-	DEFAULT_ISO_DIR=1
-	OLDPWD=$(pwd)
-	cd "$SCRIPT_DIR"
-	# default to the veewee/iso directory
-	if [ ! -d "../../../iso" ]; then
-		mkdir "../../../iso"
-		chown $VEEWEE_UID:$VEEWEE_GID "../../../iso"
-	fi
-	OUT_DIR="$(cd "$SCRIPT_DIR"; cd ../../../iso; pwd)"
-	cd "$OLDPWD" # Rest of script depends on being in the working directory if we were passed relative paths
-else
-	OUT_DIR="$2"
-fi
-
-if [ ! -d "$OUT_DIR" ]; then
+OUT_DIR="$2"
+if [ -z "$OUT_DIR" ]; then
+	exit_with_error "Currently an explicit output directory is required as the second argument."
+elif [ ! -d "$OUT_DIR" ]; then
 	msg_status "Destination dir $OUT_DIR doesn't exist, creating.."
 	mkdir -p "$OUT_DIR"
 fi
 
-MNT_ESD=$(/usr/bin/mktemp -d /tmp/veewee-osx-esd.XXXX)
-msg_status "Attaching input OS X installer image"
-hdiutil attach "$ESD" -mountpoint "$MNT_ESD" -nobrowse -owners on
-if [ $? -ne 0 ]; then
-	[ ! -e "$ESD" ] && msg_error "Could not find $ESD in $(pwd)"
-	msg_error "Could not mount $ESD on $MNT_ESD"
-	exit 1
+ESD="$INSTALLER_PATH/Contents/SharedSupport/InstallESD.dmg"
+if [ ! -e "$ESD" ]; then
+	exit_with_error "Can't locate an InstallESD.dmg in this source location $ESD!"
 fi
 
-msg_status "Mounting BaseSystem.."
-BASE_SYSTEM_DMG="$MNT_ESD/BaseSystem.dmg"
-MNT_BASE_SYSTEM=$(/usr/bin/mktemp -d /tmp/veewee-osx-basesystem.XXXX)
-[ ! -e "$BASE_SYSTEM_DMG" ] && msg_error "Could not find BaseSystem.dmg in $MNT_ESD"
-hdiutil attach "$BASE_SYSTEM_DMG" -mountpoint "$MNT_BASE_SYSTEM" -nobrowse -owners on
-if [ $? -ne 0 ]; then
-	msg_error "Could not mount $BASE_SYSTEM_DMG on $MNT_BASE_SYSTEM"
-	exit 1
+SYSVER_PLIST_PATH="$INSTALLER_PATH/Contents/SharedSupport/InstallInfo.plist"
+if [ ! -e "$SYSVER_PLIST_PATH" ]; then
+	exit_with_error "Can't locate InstallInfo.plist in $INSTALLER_PATH/Contents/SharedSupport/!"
 fi
-SYSVER_PLIST_PATH="$MNT_BASE_SYSTEM/System/Library/CoreServices/SystemVersion.plist"
 
-DMG_OS_VERS=$(/usr/libexec/PlistBuddy -c 'Print :ProductVersion' "$SYSVER_PLIST_PATH")
-DMG_OS_VERS_MAJOR=$(echo $DMG_OS_VERS | awk -F "." '{print $2}')
-DMG_OS_VERS_MINOR=$(echo $DMG_OS_VERS | awk -F "." '{print $3}')
-DMG_OS_BUILD=$(/usr/libexec/PlistBuddy -c 'Print :ProductBuildVersion' "$SYSVER_PLIST_PATH")
-msg_status "OS X version detected: 10.$DMG_OS_VERS_MAJOR.$DMG_OS_VERS_MINOR, build $DMG_OS_BUILD"
+DMG_OS_VERS=$(/usr/libexec/PlistBuddy -c 'Print :System\ Image\ Info:version' "$SYSVER_PLIST_PATH")
+DMG_OS_VERS_MAJOR=$(echo $DMG_OS_VERS | awk -F "." '{print $1}')
+DMG_OS_VERS_MINOR=$(echo $DMG_OS_VERS | awk -F "." '{print $2}')
+DMG_OS_VERS_PATCH=$(echo $DMG_OS_VERS | awk -F "." '{print $3}')
+msg_status "macOS version detected: $DMG_OS_VERS_MAJOR.$DMG_OS_VERS_MINOR.$DMG_OS_VERS_PATCH"
 
-msg_status "Unmounting BaseSystem.."
-hdiutil detach "$MNT_BASE_SYSTEM"
+HOST_OS_VERS=$(sw_vers -productVersion)
+HOST_OS_VERS_MAJOR=$(echo $HOST_OS_VERS | awk -F "." '{print $1}')
+HOST_OS_VERS_MINOR=$(echo $HOST_OS_VERS | awk -F "." '{print $2}')
+HOST_OS_VERS_PATCH=$(echo $HOST_OS_VERS | awk -F "." '{print $3}')
+msg_status "host macOS version detected: $HOST_OS_VERS_MAJOR.$HOST_OS_VERS_MINOR.$HOST_OS_VERS_PATCH"
+
+if [ "$DMG_OS_VERS_MAJOR" != "$DMG_OS_VERS_MAJOR" ] || [ "$DMG_OS_VERS_MINOR" != "$HOST_OS_VERS_MINOR" ]; then
+	exit_with_error "Unfortunately prepare_vdi can only generate images of same version as the host"
+fi
 
 if [ -z "$OUTPUT_DMG" ]; then
-  OUTPUT_DMG="$OUT_DIR/macOS_${DMG_OS_VERS}_${DMG_OS_BUILD}.vdi"
+  OUTPUT_DMG="$OUT_DIR/macOS_${DMG_OS_VERS}.vdi"
+elif [ -e "$OUTPUT_DMG" ]; then
+  exit_with_error "Output file $OUTPUT_DMG already exists! We're not going to overwrite it, exiting.."
 fi
 
-if [ -e "$OUTPUT_DMG" ]; then
-	msg_error "Output file $OUTPUT_DMG already exists! We're not going to overwrite it, exiting.."
-	hdiutil detach -force "$MNT_ESD"
-	exit 1
+if [ $DMG_OS_VERS_MINOR -ge 13 ]; then
+  if [ $DISABLE_APFS = 1 ]; then
+	  FSTYPE="HFS+J"
+  else
+    FSTYPE="APFS"
+  fi
+	OSPACKAGE="$INSTALLER_PATH/Contents/SharedSupport/InstallInfo.plist"
+else
+	FSTYPE="HFS+J"
+	MNT_ESD=$(/usr/bin/mktemp -d /tmp/veewee-osx-esd.XXXX)
+	
+	msg_status "Attaching input OS X installer image"
+	hdiutil attach "$ESD" -mountpoint "$MNT_ESD" -nobrowse -owners on
+	if [ $? -ne 0 ]; then
+		[ ! -e "$ESD" ] && exit_with_error "Could not find $ESD in $(pwd)"
+		exit_with_error "Could not mount $ESD on $MNT_ESD"
+	fi
+
+	OSPACKAGE="$MNT_ESD/Packages/OSInstall.mpkg"
 fi
 
 # Build our post-installation pkg that will create a user and enable ssh
 msg_status "Making firstboot installer pkg.."
 create_firstboot_pkg
 if [ -z "$BUILT_PKG" ] || [ ! -e "$BUILT_PKG" ]; then
-  msg_error "Failed building the firstboot installer pkg, exiting.."
-  exit 1
+  exit_with_error "Failed building the firstboot installer pkg, exiting.."
 fi
 
-BASE_SYSTEM_DMG_RW="$(/usr/bin/mktemp /tmp/veewee-osx-basesystem-rw.XXXX).dmg"
-DISK_SIZE_GB=32
-DISK_SIZE_BYTES=$(($DISK_SIZE_GB * 1024 * 1024 * 1024))
-msg_status "Creating empty read-write DMG located at $BASE_SYSTEM_DMG_RW.."
-hdiutil create -size "${DISK_SIZE_GB}g" -type SPARSE -fs HFS+J -volname "Macintosh HD" -uid 0 -gid 80 -mode 1775 "$BASE_SYSTEM_DMG_RW"
+MNT_SPARSEIMAGE=$(/usr/bin/mktemp -d /tmp/prepare_vdi_mnt_sparseimage.XXXX)
+SPARSEIMAGE="$(/usr/bin/mktemp /tmp/prepare_vdi.XXXX).sparseimage"
 
-BASE_SYSTEM_DMG_RW_SPARSE=$BASE_SYSTEM_DMG_RW.sparseimage
-msg_status "Mounting empty read-write DMG located at $BASE_SYSTEM_DMG_RW.."
-hdiutil attach "$BASE_SYSTEM_DMG_RW_SPARSE" -mountpoint "$MNT_BASE_SYSTEM" -nobrowse -owners on
+msg_status "Creating DMG of "${DISK_SIZE_GB}g" with $FSTYPE located at $SPARSEIMAGE.."
+if ! hdiutil create -size "${DISK_SIZE_GB}g" -type SPARSE -fs "$FSTYPE" -volname "Macintosh HD" -uid 0 -gid 80 -mode 1775 "$SPARSEIMAGE"; then
+  exit_with_error "Failed creating the disk image"
+fi
+
+msg_status "Mounting empty read-write DMG located at $SPARSEIMAGE.."
+hdiutil attach "$SPARSEIMAGE" -mountpoint "$MNT_SPARSEIMAGE" -nobrowse -owners on
 
 msg_status "Installing macOS"
-installer -verboseR -dumplog -pkg "$MNT_ESD/Packages/OSInstall.mpkg" -target "$MNT_BASE_SYSTEM"
+installer -verboseR -dumplog -pkg "$OSPACKAGE" -target "$MNT_SPARSEIMAGE"
 if [ $? -ne 0 ]; then
-	msg_error "Failed installing macOS"
-	exit 1
+	exit_with_error "Failed installing macOS"
 fi
 
 msg_status "Installing firstboot installer pkg"
-installer -pkg "$BUILT_PKG" -target "$MNT_BASE_SYSTEM"
+installer -pkg "$BUILT_PKG" -target "$MNT_SPARSEIMAGE"
 if [ $? -ne 0 ]; then
-	msg_error "Failed installing the firstboot installer pkg"
-	exit 1
+	exit_with_error "Failed installing the firstboot installer pkg"
 fi
 
 # Unmount and remount to make sure that is synchronized.
-hdiutil detach -quiet -force "$MNT_BASE_SYSTEM" || echo > /dev/null
-MOUNTOUTPUT=$(hdiutil attach "$BASE_SYSTEM_DMG_RW_SPARSE" -mountpoint "$MNT_BASE_SYSTEM" -nobrowse -owners on)
+msg_status "Remounting $SPARSEIMAGE"
+hdiutil detach -quiet -force "$MNT_SPARSEIMAGE" || echo > /dev/null
+MOUNTOUTPUT=$(hdiutil attach "$SPARSEIMAGE" -mountpoint "$MNT_SPARSEIMAGE" -nobrowse -owners on)
 DISK_DEV=$(grep GUID_partition_scheme <<< "$MOUNTOUTPUT" | cut -f1 | tr -d '[:space:]')
+DISK_SIZE_BYTES=$(($DISK_SIZE_GB * 1024 * 1024 * 1024))
 
-msg_status "Exporting $OUTPUT_DMG"
-cat "$DISK_DEV" | VBoxManage convertfromraw stdin "$OUTPUT_DMG" "$DISK_SIZE_BYTES"
+if [ ! -e "$DISK_DEV" ]; then
+	exit_with_error "Failed to find the device file of the image"
+fi
+
+msg_status "Exporting from $DISK_DEV to $OUTPUT_DMG"
+VBoxManage convertfromraw stdin "$OUTPUT_DMG" "$DISK_SIZE_BYTES" < "$DISK_DEV"
+
+msg_status "Checksumming output image.."
+MD5=$(md5 -q "$OUTPUT_DMG" | tee "$OUTPUT_DMG.md5")
+msg_status "MD5: $MD5"
 
 if [ -n "$SUDO_UID" ] && [ -n "$SUDO_GID" ]; then
 	msg_status "Fixing permissions.."
@@ -266,8 +266,7 @@ if [ -n "$SUDO_UID" ] && [ -n "$SUDO_GID" ]; then
 		"$OUT_DIR"
 fi
 
-msg_status "Checksumming output image.."
-MD5=$(md5 -q "$OUTPUT_DMG")
-msg_status "MD5: $MD5"
-
 msg_status "Done. Built image is located at $OUTPUT_DMG. Add this iso and its checksum to your template."
+
+cleanup
+exit 0

--- a/prepare_iso/support/user.plist
+++ b/prepare_iso/support/user.plist
@@ -4,7 +4,13 @@
 <dict>
 	<key>authentication_authority</key>
 	<array>
-		<string>;ShadowHash;</string>
+		<string>;ShadowHash;HASHLIST:&lt;SALTED-SHA512-PBKDF2&gt;</string>
+	</array>
+	<key>ShadowHashData</key>
+	<array>
+			<data>
+			${ShadowHashData}
+			</data>
 	</array>
 	<key>generateduid</key>
 	<array>

--- a/scripts/support/arc4random.py
+++ b/scripts/support/arc4random.py
@@ -1,0 +1,59 @@
+'''py-arc4random
+
+Basic python 2.7/3 implementation of OpenBSDs arc4random PRNG.
+
+https://github.com/rolandshoemaker/py-arc4random
+
+Examples
+>>> import arc4random
+>>> arc4random.rand()
+2057591911
+>>> arc4random.randrange(50,100)
+75
+>>> arc4random.randsample(0,1, 10)
+[1, 1, 0, 1, 1, 0, 1, 1, 1, 1]
+'''
+
+import random
+
+def rand():
+    key = random.sample(range(256), 256) # something
+    seeds = _RC4PRGA(_RC4keySchedule(key))
+    return (seeds[0]<<24)|(seeds[1]<<16)|(seeds[2]<<8)|seeds[3]
+
+def randrange(x, y=None):
+    if y:
+        return (rand()%((y-x)+1))+x
+    else:
+        return rand()%(x+1)
+
+def randsample(Rmin, Rmax, size):
+    sample = []
+    for i in range(size):
+        sample.append((rand()%((Rmax-Rmin)+1))+Rmin)
+    return sample
+
+def _RC4keySchedule(key):
+    sbox = list(range(256))
+    x = 0
+    keySize = len(key)
+    for i in sbox:
+        x = (x+i+key[i%keySize])%256
+        _swap(sbox, i, x)
+    return sbox
+
+def _RC4PRGA(state):
+    x, y = 0, 0
+    seeds = []
+    # Discard first 1536 bytes of the keystream according to RFC4345 as they may reveal information
+    # about key used (a set of these keys could reveal information about the source for our key)
+    for i in range((1536//4)+4):
+        x = (x+1)%256
+        y = (y+state[x])%256
+        _swap(state, x, y)
+        if i >= (1536//4):
+            seeds.append(state[(state[x]+state[y])%256])
+    return seeds
+
+def _swap(listy, n1, n2):
+    listy[n1], listy[n2] = listy[n2], listy[n1]

--- a/scripts/support/generatehash.py
+++ b/scripts/support/generatehash.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+
+import sys
+import shadowhash
+import base64
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        hash = shadowhash.generate(sys.argv[1])
+        print base64.b64encode(hash)

--- a/scripts/support/pbkdf2.py
+++ b/scripts/support/pbkdf2.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""
+    pbkdf2
+    ~~~~~~
+    This module implements pbkdf2 for Python.  It also has some basic
+    tests that ensure that it works.  The implementation is straightforward
+    and uses stdlib only stuff and can be easily be copy/pasted into
+    your favourite application.
+    Use this as replacement for bcrypt that does not need a c implementation
+    of a modified blowfish crypto algo.
+    Example usage:
+    >>> pbkdf2_hex('what i want to hash', 'the random salt')
+    'fa7cc8a2b0a932f8e6ea42f9787e9d36e592e0c222ada6a9'
+    How to use this:
+    1.  Use a constant time string compare function to compare the stored hash
+        with the one you're generating::
+            def safe_str_cmp(a, b):
+                if len(a) != len(b):
+                    return False
+                rv = 0
+                for x, y in izip(a, b):
+                    rv |= ord(x) ^ ord(y)
+                return rv == 0
+    2.  Use `os.urandom` to generate a proper salt of at least 8 byte.
+        Use a unique salt per hashed password.
+    3.  Store ``algorithm$salt:costfactor$hash`` in the database so that
+        you can upgrade later easily to a different algorithm if you need
+        one.  For instance ``PBKDF2-256$thesalt:10000$deadbeef...``.
+    :copyright: (c) Copyright 2011 by Armin Ronacher.
+    :license: BSD, see LICENSE for more details.
+"""
+# https://github.com/mitsuhiko/python-pbkdf2
+
+import hmac
+import hashlib
+from struct import Struct
+from operator import xor
+from itertools import izip, starmap
+
+
+_pack_int = Struct('>I').pack
+
+
+def pbkdf2_hex(data, salt, iterations=1000, keylen=24, hashfunc=None):
+    """Like :func:`pbkdf2_bin` but returns a hex encoded string."""
+    return pbkdf2_bin(data, salt, iterations, keylen, hashfunc).encode('hex')
+
+
+def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
+    """Returns a binary digest for the PBKDF2 hash algorithm of `data`
+    with the given `salt`.  It iterates `iterations` time and produces a
+    key of `keylen` bytes.  By default SHA-1 is used as hash function,
+    a different hashlib `hashfunc` can be provided.
+    """
+    hashfunc = hashfunc or hashlib.sha1
+    mac = hmac.new(data, None, hashfunc)
+    def _pseudorandom(x, mac=mac):
+        h = mac.copy()
+        h.update(x)
+        return map(ord, h.digest())
+    buf = []
+    for block in xrange(1, -(-keylen // mac.digest_size) + 1):
+        rv = u = _pseudorandom(salt + _pack_int(block))
+        for i in xrange(iterations - 1):
+            u = _pseudorandom(''.join(map(chr, u)))
+            rv = starmap(xor, izip(rv, u))
+        buf.extend(rv)
+    return ''.join(map(chr, buf))[:keylen]
+
+
+def test():
+    failed = []
+    def check(data, salt, iterations, keylen, expected):
+        rv = pbkdf2_hex(data, salt, iterations, keylen)
+        if rv != expected:
+            print 'Test failed:'
+            print '  Expected:   %s' % expected
+            print '  Got:        %s' % rv
+            print '  Parameters:'
+            print '    data=%s' % data
+            print '    salt=%s' % salt
+            print '    iterations=%d' % iterations
+            print
+            failed.append(1)
+
+    # From RFC 6070
+    check('password', 'salt', 1, 20,
+          '0c60c80f961f0e71f3a9b524af6012062fe037a6')
+    check('password', 'salt', 2, 20,
+          'ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957')
+    check('password', 'salt', 4096, 20,
+          '4b007901b765489abead49d926f721d065a429c1')
+    check('passwordPASSWORDpassword', 'saltSALTsaltSALTsaltSALTsaltSALTsalt',
+          4096, 25, '3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038')
+    check('pass\x00word', 'sa\x00lt', 4096, 16,
+          '56fa6aa75548099dcc37d7f03425e0c3')
+    # This one is from the RFC but it just takes for ages
+    ##check('password', 'salt', 16777216, 20,
+    ##      'eefe3d61cd4da4e4e9945b3d6ba2158c2634e984')
+
+    # From Crypt-PBKDF2
+    check('password', 'ATHENA.MIT.EDUraeburn', 1, 16,
+          'cdedb5281bb2f801565a1122b2563515')
+    check('password', 'ATHENA.MIT.EDUraeburn', 1, 32,
+          'cdedb5281bb2f801565a1122b25635150ad1f7a04bb9f3a333ecc0e2e1f70837')
+    check('password', 'ATHENA.MIT.EDUraeburn', 2, 16,
+          '01dbee7f4a9e243e988b62c73cda935d')
+    check('password', 'ATHENA.MIT.EDUraeburn', 2, 32,
+          '01dbee7f4a9e243e988b62c73cda935da05378b93244ec8f48a99e61ad799d86')
+    check('password', 'ATHENA.MIT.EDUraeburn', 1200, 32,
+          '5c08eb61fdf71e4e4ec3cf6ba1f5512ba7e52ddbc5e5142f708a31e2e62b1e13')
+    check('X' * 64, 'pass phrase equals block size', 1200, 32,
+          '139c30c0966bc32ba55fdbf212530ac9c5ec59f1a452f5cc9ad940fea0598ed1')
+    check('X' * 65, 'pass phrase exceeds block size', 1200, 32,
+          '9ccad6d468770cd51b10e6a68721be611a8b4d282601db3b36be9246915ec82a')
+
+    raise SystemExit(bool(failed))
+
+
+if __name__ == '__main__':
+    test()

--- a/scripts/support/plistutils.py
+++ b/scripts/support/plistutils.py
@@ -1,0 +1,38 @@
+'''plist utility functions'''
+
+from Foundation import NSPropertyListSerialization
+from Foundation import NSPropertyListXMLFormat_v1_0
+from Foundation import NSPropertyListBinaryFormat_v1_0
+
+class FoundationPlistException(Exception):
+    """Basic exception for plist errors"""
+    pass
+
+
+def write_plist(dataObject, pathname=None, plist_format=None):
+    '''
+    Write 'rootObject' as a plist to pathname or return as a string.
+    '''
+    if plist_format == 'binary':
+        plist_format = NSPropertyListBinaryFormat_v1_0
+    else:
+        plist_format = NSPropertyListXMLFormat_v1_0
+    
+    plistData, error = (
+        NSPropertyListSerialization.
+        dataFromPropertyList_format_errorDescription_(
+            dataObject, plist_format, None))
+    if plistData is None:
+        if error:
+            error = error.encode('ascii', 'ignore')
+        else:
+            error = "Unknown error"
+        raise FoundationPlistException(error)
+    if pathname:
+        if plistData.writeToFile_atomically_(pathname, True):
+            return
+        else:
+            raise FoundationPlistException(
+                "Failed to write plist data to %s" % filepath)
+    else:
+        return plistData

--- a/scripts/support/shadowhash.py
+++ b/scripts/support/shadowhash.py
@@ -1,0 +1,37 @@
+'''Functions for generating ShadowHashData'''
+
+import hashlib
+
+import arc4random
+import pbkdf2
+
+import plistutils
+
+
+def make_salt(saltlen):
+    '''Generate a random salt'''
+    salt = ''
+    for char in arc4random.randsample(0, 255, saltlen):
+        salt += chr(char)
+    return salt
+
+
+def generate(password):
+    '''Generate a ShadowHashData structure as used by macOS 10.8+'''
+    iterations = arc4random.randrange(30000, 50000)
+    salt = make_salt(32)
+    keylen = 128
+    try:
+        entropy = hashlib.pbkdf2_hmac(
+            'sha512', password, salt, iterations, dklen=keylen)
+    except AttributeError:
+        # old Python, do it a different way
+        entropy = pbkdf2.pbkdf2_bin(
+            password, salt, iterations=iterations, keylen=keylen,
+            hashfunc=hashlib.sha512)
+
+    data = {'SALTED-SHA512-PBKDF2': {'entropy': buffer(entropy),
+                                     'iterations': iterations,
+                                     'salt': buffer(salt)},
+                       }
+    return plistutils.write_plist(data, plist_format='binary')

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -3,7 +3,7 @@ date > /etc/box_build_time
 OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
 
 # Set computer/hostname
-COMPNAME=osx-10_${OSX_VERS}
+COMPNAME=macos-10-${OSX_VERS}
 scutil --set ComputerName ${COMPNAME}
 scutil --set HostName ${COMPNAME}.vagrantup.com
 

--- a/scripts/vmware.sh
+++ b/scripts/vmware.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-TOOLS_PATH="/Users/$USERNAME/darwin.iso"
+# Globbing here: VMware Fusion >= 8.5.4 includes a second
+# 'darwinPre15.iso' for any OS X guests pre-10.11
+TOOLS_PATH=$(find "/Users/$USERNAME/" -name '*darwin*.iso' -print)
+
 # VMware Fusion specific items
 if [ -e .vmfusion_version ] || [[ "$PACKER_BUILDER_TYPE" == vmware* ]]; then
     if [ ! -e "$TOOLS_PATH" ]; then


### PR DESCRIPTION
I am one of those unlucky guys who have unfortunately discovered this project too late after Apple released Sierra 10.12.4 :-(

I am using it for prototyping my personal projects, and the price of WMware + vagrant wmware plugin made me drop the alternative WMware + AutoDMG + vfuse for now, so I took a look to how AutoDMG worked and I created a modified version of your prepare_iso.sh which uses ```installer -verboseR -dumplog -pkg "$MNT_ESD/Packages/OSInstall.mpkg" -target "$MNT_BASE_SYSTEM"``` to install macOS in a disk image that gets converted into a virtual box image by doing ```cat "$DISK_DEV" | VBoxManage convertfromraw stdin "$OUTPUT_DMG" "$DISK_SIZE_BYTES"```. 

I also created a small tool to generate and export a OVF which can be used by the packer builder virtualbox-ovf. :-)

```
$ mkdir -p out; cd out;
$ sudo ../prepare_iso/prepare_vdi.sh -D DISABLE_REMOTE_MANAGEMENT /Applications/Install\ macOS\ Sierra.app/ .
$ ../prepare_iso/prepare_ovf.sh macOS_10.12.4_16E195.vdi
$ packer build -var provisioning_delay=30 -var source_path=macOS_10.12.4_16E195.ovf ../packer/template.json
```