### PR TITLE
Build to different directories to avoid filling boot drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ packer build \
   template.json
 ```
 
+### Building to a device with more space
+
+Local VM builds take up a lot of space. It's possible to make packer work in different directories.
+
+* [`PACKER_CACHE_DIR`](https://www.packer.io/docs/other/environment-variables.html#packer_cache_dir) is an out-of-the-box environment variable that configures where it will cache ISOs etc.
+* `PACKER_OUTPUT_DIR`: configure where packer will build artifacts (like OVF files) to
+* `PACKER_VAGRANT_BOX_DIR`: configure where packer will build vagrant boxes via the post-processor to.
+
+**Note:** don't make `PACKER_OUTPUT_DIR` and `PACKER_VAGRANT_BOX_DIR` the same place. `keep_input_artifacts` in the post-processor defaults to `false`, and it removes them by removing the directory, not the individual files. So if you use the same place, you'll end up with no output at all (packer `v1.0.0`).
 
 ## Automated installs on OS X
 

--- a/packer/template.json
+++ b/packer/template.json
@@ -6,6 +6,7 @@
       "guest_os_type": "win-8",
       "iso_checksum_type": "none",
       "iso_url": "{{user `iso_url`}}",
+      "output_directory": "{{user `output_directory`}}",
       "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
       "ssh_port": 22,
       "ssh_username": "{{user `username`}}",
@@ -32,6 +33,7 @@
       "guest_os_type": "darwin12-64",
       "iso_checksum_type": "none",
       "iso_url": "{{user `iso_url`}}",
+      "output_directory": "{{user `output_directory`}}",
       "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_port": 22,
@@ -62,6 +64,7 @@
       "iso_checksum_type": "none",
       "iso_interface": "sata",
       "iso_url": "{{user `iso_url`}}",
+      "output_directory": "{{user `output_directory`}}",
       "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
       "ssh_port": 22,
       "ssh_username": "{{user `username`}}",
@@ -85,7 +88,10 @@
   ],
   "min_packer_version": "0.7.0",
   "post-processors": [
-    "vagrant"
+    {
+      "type": "vagrant",
+      "output": "{{user `vagrant_box_directory`}}/packer_{{.BuildName}}_{{.Provider}}.box"
+    }
   ],
   "provisioners": [
     {
@@ -136,11 +142,13 @@
     "install_vagrant_keys": "true",
     "install_xcode_cli_tools": "true",
     "iso_url": "OSX_InstallESD_10.11.1_15B42.dmg",
+    "output_directory": "{{env `PACKER_OUTPUT_DIR`}}",
     "password": "vagrant",
     "provisioning_delay": "0",
     "puppet_version": "none",
     "puppet_agent_version": "none",
     "update_system": "true",
-    "username": "vagrant"
+    "username": "vagrant",
+    "vagrant_box_directory": "{{env `PACKER_VAGRANT_BOX_DIR`}}"
   }
 }


### PR DESCRIPTION
Fixes #80. Note: haven't tried it out, but this is ported over from where I used it inside improbable-io/packer-windows#improbable-io