### PR TITLE
Ensure Xcode CLI Tools has most recent version selected

### DIFF
--- a/scripts/xcode-cli-tools.sh
+++ b/scripts/xcode-cli-tools.sh
@@ -13,7 +13,7 @@ if [ "$OSX_VERS" -ge 9 ]; then
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     # find the CLI Tools update
-    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
     # install it
     softwareupdate -i "$PROD" --verbose
     rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress


### PR DESCRIPTION
When packaging 10.13 High Sierra, `softwareupdate -l` has the following output:

```
Software Update Tool

Finding available software
Software Update found the following new or updated software:
   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2
	Command Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]
   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.1
	Command Line Tools (macOS High Sierra version 10.13) for Xcode (9.1), 177264K [recommended]
   * macOS 10.13.1 Update-10.13.1
	macOS 10.13.1 Update (10.13.1), 1435937K [recommended] [restart]
   * iTunesX-12.7.1
	iTunes (12.7.1), 257176K [recommended]
```

Previously, the first matching Xcode CLI tools in the list was being selected for installation, which is not the most recent.

This change should ensure that the last matching item - the most recent - is selected instead.