### PR TITLE
Support building High Sierra images for Parallels Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,28 @@ packer build \
   template.json
 ```
 
+### Parallels support via ```prepare_vdi.sh```, ```prepare_pvm.sh``` and packer parallels-pvm
+
+This approach requires VirtualBox and Parallels Desktop.
+
+#### Installing and exporting to a VirtualBox virtual disk image
+
+The ```prepare_vdi.sh``` command will run the installer's ```OSInstall.pkg``` or ```InstallInfo.plist``` creating a fresh install in a temporary disk image which is converted into a VDI disk image.
+
+#### Generating a Parallels virtual machine
+The ```prepare_pvm.sh``` script converts a virtual disk image into Parallels's hard disk (.hdd) and creates a Parallels virtual machine (.pvm) with that disk attached.
+
+#### Generating a packer box using the parallels-pvm builder
+
+Finally, the parallels-pvm builder allows to use the previously generated virtual machine to generate the provisioned packer box.
+
+```
+packer build \
+  -only parallels-pvm \
+  -var source_path=macOS_10.13.pvm \
+  template.json
+```
+
 ## Box sizes
 
 A built box with CLI tools, Puppet and Chef is over 5GB in size. It might be advisable to remove (with care) some unwanted applications in an additional postinstall script. It should also be possible to modify the OS X installer package to install fewer components, but this is non-trivial. One can also supply a custom "choice changes XML" file to modify the installer choices in a supported way, but from my testing, this only allows removing several auxiliary packages that make up no more than 6-8% of the installed footprint (for example, multilingual voices and dictionary files).

--- a/packer/template.json
+++ b/packer/template.json
@@ -105,6 +105,22 @@
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
         ["modifyvm", "{{.Name}}", "--vram", "128"]
       ]
+    },
+    {
+      "boot_wait": "2s",
+      "source_path": "{{user `source_path`}}",
+      "shutdown_command": "echo '{{user `username`}}'|sudo -S shutdown -h now",
+      "ssh_port": 22,
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+      "ssh_wait_timeout": "10000s",
+      "parallels_tools_flavor": "mac",
+      "type": "parallels-pvm",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--cpus", "2"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ]
     }
   ],
   "min_packer_version": "0.7.0",

--- a/prepare_iso/prepare_pvm.sh
+++ b/prepare_iso/prepare_pvm.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+
+usage() {
+	cat <<EOF
+Usage:
+$(basename "$0") "/path/to/diskimage.vdi"
+
+Description:
+Converts virtual disk image to Parallels hard disk (HDD) and creates Parallels virtual machine from that image
+
+EOF
+}
+
+cleanup() {
+  if [ -n "$VM" ] && prlctl list | grep -q "$VM"; then
+    prlctl unregister "$VM"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+msg_status() {
+	echo "\033[0;32m-- $1\033[0m"
+}
+
+if [ ! -f "$1" ]; then
+  usage
+	exit 1
+fi
+
+TIMESTAMP=$(date +"%s")
+VM="macOS_${TIMESTAMP}"
+HARDDRIVE="$1"
+
+msg_status "Creating new virtual machine"
+prlctl create "$VM" --ostype macos --no-hdd --dst="$(dirname "$HARDDRIVE")"
+
+msg_status "Converting VDI to HDD"
+prl_convert "$HARDDRIVE" --allow-no-os --no-reconfig --dst="$(dirname "$HARDDRIVE")/$VM.pvm"
+prl_disk_tool convert --merge --hdd "$(dirname "$HARDDRIVE")/$VM.pvm/$(basename "${HARDDRIVE%.vdi}.hdd")"
+
+msg_status "Attaching HDD to Parallels VM"
+prlctl set "$VM" --device-add hdd --image "$(dirname "$HARDDRIVE")/$VM.pvm/$(basename "${HARDDRIVE%.vdi}.hdd")"
+
+msg_status "Unregistring the virtual machine"
+prlctl unregister "$VM"
+
+msg_status "Done. Virtual machine export located at $(dirname "$HARDDRIVE")/$VM.pvm."


### PR DESCRIPTION
This is based on prepare_vdi.sh script and uses Parallels disk tools to convert a VDI into Parallels internal HDD format. The new script prepare_pvm.sh creates a Parallels virtual machine (.pvm) with that disk attached. The new VM is used by the new parallels-pvm builder to build an image for vagrant.

Parallels disk tools should come with any installation of Parallels Desktop.

#87 