### PR TITLE
Prevent auto downloading High Sierra in older OSs

### DIFF
--- a/scripts/system-update.sh
+++ b/scripts/system-update.sh
@@ -1,6 +1,15 @@
+#!/bin/bash
+
 if [ "$UPDATE_SYSTEM" != "true" ] && [ "$UPDATE_SYSTEM" != "1" ]; then
   exit
 fi
 
+MAJOR_VERSION=$(/usr/bin/sw_vers -productVersion | /usr/bin/cut -d '.' -f 2,2)
+
+if [ "$MAJOR_VERSION" -lt 13 ]; then
+  echo "Ignoring automatic High Sierra updates..."
+  softwareupdate --ignore "Install macOS High Sierra"
+fi
+
 echo "Downloading and installing system updates..."
-softwareupdate -i -a
+softwareupdate --install --all


### PR DESCRIPTION
In Yosemite, the High Sierra installer is automatically downloaded to `/Applications` when installing all updates. This change ignores that update to keep the final box clean and without unncessary content.