### PR TITLE
support for Catalina softwareupdate output

### DIFF
--- a/scripts/xcode-cli-tools.sh
+++ b/scripts/xcode-cli-tools.sh
@@ -13,7 +13,7 @@ if [ "$OSX_VERS" -ge 9 ]; then
     # in Apple's SUS catalog
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
     # find the CLI Tools update
-    PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | sed 's/Label: //g' | tr -d '\n')
     # install it
     softwareupdate -i "$PROD" --verbose
     rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress


### PR DESCRIPTION
In Catalina, the output for software update appears so:

```
Software Update Tool

Finding available software
Software Update found the following new or updated software:
* Label: Command Line Tools for Xcode-11.2
	Title: Command Line Tools for Xcode, Version: 11.2, Size: 224942K, Recommended: YES,
* Label: Command Line Tools for Xcode-11.3
	Title: Command Line Tools for Xcode, Version: 11.3, Size: 224878K, Recommended: YES,
```

`softwareupdate -i` expect "Command Line Tools for Xcode-11.2" not "Label: Command Line Tools for Xcode-11.2". Support for Mojave/High Sierra is preserved, since the added sed pipe won't change output without "Label: ".